### PR TITLE
Warn when checking liveness under action or state constraints.

### DIFF
--- a/general/docs/changelogs/ch1_6_1.md
+++ b/general/docs/changelogs/ch1_6_1.md
@@ -37,6 +37,7 @@ The high level changelog is available at http://research.microsoft.com/en-us/um/
  * `InstanceName!Definition`
 * The Initial predicate / Next-state text areas were no longer interpreting a TAB as 'advance focus' due to a regression introduced when we moved to multi-line support for these text areas in 1.6.0. Both text areas now interpret a TAB as a focus advance; a TAB in the 'Init:' text area moves focus to the 'Next:' text area and a TAB in that text area advances the focus to the 'What is the model?' section.
 * New models now open a Model Editor instance with only a single tab - the Model Overview page. Running the model will open the Results tab, or should the user want to work immediately with evaluating constant expressions, there is a link at the bottom of the Model Overview page which will open the Results tab (as well as the Constant Expressions tab should the user have configured their preferences to show this in its own tab.)
+* Warn when checking liveness under action or state constraints (see [Specifying Systems](https://lamport.azurewebsites.net/tla/book.html) section 14.3.5 on page 247 for details).
 
 ##### Spec Explorer
 * Right-clicking on model snapshots was incorrectly presenting the choice to rename the snapshot; this has been corrected.

--- a/org.lamport.tla.toolbox.tool.tlc.ui/src/org/lamport/tla/toolbox/tool/tlc/output/data/TLCModelLaunchDataProvider.java
+++ b/org.lamport.tla.toolbox.tool.tlc.ui/src/org/lamport/tla/toolbox/tool/tlc/output/data/TLCModelLaunchDataProvider.java
@@ -162,6 +162,7 @@ public class TLCModelLaunchDataProvider implements ITLCOutputListener
 	private int fpIndex;
 
 	private boolean isSymmetryWithLiveness = false;
+	private boolean isConstraintsWithLiveness = false;
 	
 	private final Object parsingLock;
 	private final AtomicBoolean parsing;
@@ -335,6 +336,11 @@ public class TLCModelLaunchDataProvider implements ITLCOutputListener
                     break;
                 case EC.TLC_FEATURE_UNSUPPORTED_LIVENESS_SYMMETRY:
                 	this.isSymmetryWithLiveness = true;
+                    setDocumentText(this.progressOutput, outputMessage, true);
+                    informPresenter(ITLCModelLaunchDataPresenter.WARNINGS);
+                    break;
+                case EC.TLC_FEATURE_LIVENESS_CONSTRAINTS:
+                	this.isConstraintsWithLiveness = true;
                     setDocumentText(this.progressOutput, outputMessage, true);
                     informPresenter(ITLCModelLaunchDataPresenter.WARNINGS);
                     break;
@@ -1154,7 +1160,10 @@ public class TLCModelLaunchDataProvider implements ITLCOutputListener
 	public boolean isSymmetryWithLiveness() {
 		return isSymmetryWithLiveness;
 	}
-	
+
+	public boolean isConstraintsWithLiveness() {
+		return isConstraintsWithLiveness;
+	}
 
 	private final static SimpleDateFormat SDF = new SimpleDateFormat(
 			"yyyy-MM-dd HH:mm:ss");

--- a/org.lamport.tla.toolbox.tool.tlc.ui/src/org/lamport/tla/toolbox/tool/tlc/ui/editor/page/MainModelPage.java
+++ b/org.lamport.tla.toolbox.tool.tlc.ui/src/org/lamport/tla/toolbox/tool/tlc/ui/editor/page/MainModelPage.java
@@ -516,7 +516,7 @@ public class MainModelPage extends BasicFormPage implements IConfigurationConsta
 					TypedSet modelValuesSet = TypedSet.parseSet(constant.getRight());
 
 					if (constant.isSymmetricalSet()) {
-						if (((CheckboxTableViewer) propertiesTable).getCheckedElements().length > 0) {
+						if (hasLivenessProperty()) {
 							modelEditor.addErrorMessage(constant.getLabel(), String.format(
 									"%s declared to be symmetric while one or more temporal formulas are set to be checked.\n"
 											+ "If the temporal formula is a liveness property, liveness checking might fail to find\n"
@@ -808,6 +808,10 @@ public class MainModelPage extends BasicFormPage implements IConfigurationConsta
 		mm.setAutoUpdate(true);
 
 		super.validatePage(switchToErrorPage);
+	}
+	
+	public boolean hasLivenessProperty() {
+		return ((CheckboxTableViewer) propertiesTable).getCheckedElements().length > 0;
 	}
 
 	public boolean workerCountCanBeModified() {

--- a/org.lamport.tla.toolbox.tool.tlc.ui/src/org/lamport/tla/toolbox/tool/tlc/ui/editor/page/advanced/AdvancedModelPage.java
+++ b/org.lamport.tla.toolbox.tool.tlc.ui/src/org/lamport/tla/toolbox/tool/tlc/ui/editor/page/advanced/AdvancedModelPage.java
@@ -32,6 +32,7 @@ import org.lamport.tla.toolbox.tool.tlc.model.TypedSet;
 import org.lamport.tla.toolbox.tool.tlc.ui.editor.DataBindingManager;
 import org.lamport.tla.toolbox.tool.tlc.ui.editor.ModelEditor;
 import org.lamport.tla.toolbox.tool.tlc.ui.editor.page.BasicFormPage;
+import org.lamport.tla.toolbox.tool.tlc.ui.editor.page.MainModelPage;
 import org.lamport.tla.toolbox.tool.tlc.ui.editor.part.ValidateableOverridesSectionPart;
 import org.lamport.tla.toolbox.tool.tlc.ui.editor.part.ValidateableSectionPart;
 import org.lamport.tla.toolbox.tool.tlc.ui.util.DirtyMarkingListener;
@@ -287,6 +288,30 @@ public class AdvancedModelPage extends BasicFormPage implements Closeable {
                 }
             }
         }
+        
+		final MainModelPage mmp = (MainModelPage) getModelEditor().getFormPage(MainModelPage.ID);
+		if (mmp.hasLivenessProperty()) {
+			if (!FormHelper.trimTrailingSpaces(constraintSource.getDocument().get()).isEmpty()) {
+				modelEditor.addErrorMessage("constraintSource", "Declaring state constraints during liveness checking is dangerous: "
+								+ "All behaviors might\nend in infinite stuttering and thus do not satisfy "
+								+ "the spec's fairness constraints. Be\nsure to check a liveness property such as"
+								+ "'<>FALSE' to verify that TLC reports liveness\nerrors. Please read section 14.3.5 "
+								+ "on page 247 of Specifying Systems for more details\n(https://lamport.azurewebsites.net/tla/book.html).",
+						this.getId(), IMessageProvider.INFORMATION,
+						UIHelper.getWidget(dm.getAttributeControl(MODEL_PARAMETER_CONSTRAINT)));
+				expandSection(dm.getSectionForAttribute(MODEL_PARAMETER_CONSTRAINT));
+			}
+			if (!FormHelper.trimTrailingSpaces(actionConstraintSource.getDocument().get()).isEmpty()) {
+				modelEditor.addErrorMessage("actionConstraintSource", "Declaring action constraints during liveness checking is dangerous: "
+							+ "All behaviors might\nend in infinite stuttering and thus do not satisfy "
+							+ "the spec's fairness constraints. Be\nsure to check a liveness property such as"
+							+ "'<>FALSE' to verify that TLC reports liveness\nerrors. Please read section 14.3.5 "
+							+ "on page 247 of Specifying Systems for more details\n(https://lamport.azurewebsites.net/tla/book.html).",
+					this.getId(), IMessageProvider.INFORMATION,
+						UIHelper.getWidget(dm.getAttributeControl(MODEL_PARAMETER_ACTION_CONSTRAINT)));
+				expandSection(dm.getSectionForAttribute(MODEL_PARAMETER_ACTION_CONSTRAINT));
+			}
+		}
 
         mm.setAutoUpdate(true);
         

--- a/org.lamport.tla.toolbox.tool.tlc.ui/src/org/lamport/tla/toolbox/tool/tlc/ui/editor/page/results/ResultPage.java
+++ b/org.lamport.tla.toolbox.tool.tlc.ui/src/org/lamport/tla/toolbox/tool/tlc/ui/editor/page/results/ResultPage.java
@@ -106,6 +106,7 @@ import org.lamport.tla.toolbox.tool.tlc.ui.editor.TLACoverageEditor;
 import org.lamport.tla.toolbox.tool.tlc.ui.editor.page.BasicFormPage;
 import org.lamport.tla.toolbox.tool.tlc.ui.editor.page.ErrorMessage;
 import org.lamport.tla.toolbox.tool.tlc.ui.editor.page.MainModelPage;
+import org.lamport.tla.toolbox.tool.tlc.ui.editor.page.advanced.AdvancedModelPage;
 import org.lamport.tla.toolbox.tool.tlc.ui.editor.page.advanced.AdvancedTLCOptionsPage;
 import org.lamport.tla.toolbox.tool.tlc.ui.editor.part.ValidateableSectionPart;
 import org.lamport.tla.toolbox.tool.tlc.ui.editor.preference.IModelEditorPreferenceConstants;
@@ -465,6 +466,17 @@ public class ResultPage extends BasicFormPage implements Closeable, ITLCModelLau
 										.createMarkerDescription(errorMessage, IMarker.SEVERITY_WARNING);
 								getModel().setMarker(marker, ModelHelper.TLC_MODEL_ERROR_MARKER_TLC);
 							}
+						}
+						if (dataProvider.isConstraintsWithLiveness()) {
+							final String errorMessage = "Liveness checking with state or action constraints might fail to find a violation. "
+									+ "Please read section 14.3.5 on page 247 of Specifying Systems "
+									+ "(https://lamport.azurewebsites.net/tla/book.html) for more details.";
+							getModelEditor().addErrorMessage(new ErrorMessage(errorMessage, "StateConstraintWarning",
+									AdvancedModelPage.ID, Arrays.asList(ISectionConstants.SEC_STATE_CONSTRAINT),
+									IModelConfigurationConstants.MODEL_PARAMETER_CONSTRAINT));
+							final Hashtable<String, Object> marker = ModelHelper
+									.createMarkerDescription(errorMessage, IMarker.SEVERITY_WARNING);
+							getModel().setMarker(marker, ModelHelper.TLC_MODEL_ERROR_MARKER_TLC);
 						}
 						break;
 					case ERRORS:

--- a/tlatools/src/tlc2/output/EC.java
+++ b/tlatools/src/tlc2/output/EC.java
@@ -48,6 +48,7 @@ public interface EC
 	 */
 	public static final int TLC_FEATURE_UNSUPPORTED = 2156;
 	public static final int TLC_FEATURE_UNSUPPORTED_LIVENESS_SYMMETRY = 2279;
+	public static final int TLC_FEATURE_LIVENESS_CONSTRAINTS = 2284;
 
     public static final int GENERAL = 1000;
     public static final int SYSTEM_OUT_OF_MEMORY = 1001;

--- a/tlatools/src/tlc2/output/MP.java
+++ b/tlatools/src/tlc2/output/MP.java
@@ -774,6 +774,16 @@ public class MP
             		+ "It might cause TLC to miss violations of the stated liveness properties. "
             		+ "Please check liveness without symmetry defined.");
             break;
+        case EC.TLC_FEATURE_LIVENESS_CONSTRAINTS:
+        	// Specifying Systems Section 14.3.5 page 247.
+        	// https://lamport.azurewebsites.net/tla/book.html
+            b.append("Declaring state or action constraints during liveness checking is dangerous: "
+            		+ "All behaviors might end in infinite stuttering and thus do not satisfy "
+            		+ "the spec's fairness constraints. Be sure to check a liveness property such as "
+            		+ "'<>FALSE' to verify that TLC reports liveness errors. Please read section 14.3.5 "
+            		+ "on page 247 of Specifying Systems (https://lamport.azurewebsites.net/tla/book.html) "
+            		+ "for more details.");
+            break;
 
         /* Liveness errors */
         case EC.TLC_LIVE_BEGRAPH_FAILED_TO_CONSTRUCT:

--- a/tlatools/src/tlc2/tool/AbstractChecker.java
+++ b/tlatools/src/tlc2/tool/AbstractChecker.java
@@ -101,6 +101,9 @@ public abstract class AbstractChecker
         		// raise warning...
 				MP.printWarning(EC.TLC_FEATURE_UNSUPPORTED_LIVENESS_SYMMETRY);
         	}
+        	if (tool.hasStateOrActionConstraints()) {
+				MP.printWarning(EC.TLC_FEATURE_LIVENESS_CONSTRAINTS);
+        	}
             // Initialization for liveness checking:
             report("initializing liveness checking");
 			IBucketStatistics stats = new DummyBucketStatistics();

--- a/tlatools/src/tlc2/tool/ITool.java
+++ b/tlatools/src/tlc2/tool/ITool.java
@@ -97,6 +97,8 @@ public interface ITool extends TraceApp {
 	/* This method determines if a pair of states satisfy the action constraints. */
 	boolean isInActions(TLCState s1, TLCState s2) throws EvalException;
 
+	boolean hasStateOrActionConstraints();
+
 	/**
 	   * This method determines if an action is enabled in the given state.
 	   * More precisely, it determines if (act.pred /\ (sub' # sub)) is

--- a/tlatools/src/tlc2/tool/impl/Tool.java
+++ b/tlatools/src/tlc2/tool/impl/Tool.java
@@ -2529,6 +2529,11 @@ public class Tool
   }
   
   @Override
+  public final boolean hasStateOrActionConstraints() {
+	  return this.getModelConstraints().length > 0 || this.getActionConstraints().length > 0;
+  }
+  
+  @Override
   public final TLCState enabled(SemanticNode pred, Context c, TLCState s0, TLCState s1) {
 		  return enabled(pred, ActionItemList.Empty, c, s0, s1, CostModel.DO_NOT_RECORD);
   }

--- a/tlatools/test-model/LivenessConstraintWarning.cfg
+++ b/tlatools/test-model/LivenessConstraintWarning.cfg
@@ -1,0 +1,8 @@
+CONSTRAINT
+Constraint
+
+SPECIFICATION
+Spec
+
+PROPERTY
+Prop

--- a/tlatools/test-model/LivenessConstraintWarning.tla
+++ b/tlatools/test-model/LivenessConstraintWarning.tla
@@ -1,0 +1,24 @@
+----------------------------- MODULE LivenessConstraintWarning -----------------------------
+EXTENDS Integers, Sequences
+
+VARIABLES pc, history
+vars == <<pc, history>>
+
+Init == /\ pc = "A" 
+        /\ history = <<>>
+
+A == /\ pc  = "A"
+     /\ pc' = "B"
+     /\ history' = history \o <<pc>>
+
+B == /\ pc  = "B"
+     /\ pc' = "A"
+     /\ UNCHANGED history 
+
+Spec == Init /\ [][A \/ B]_vars /\ WF_vars(A \/ B)
+
+Constraint == Len(history) < 3
+
+Prop == <>(pc = "Done")
+
+==============================================================================

--- a/tlatools/test/tlc2/tool/liveness/LivenessConstraintWarning.java
+++ b/tlatools/test/tlc2/tool/liveness/LivenessConstraintWarning.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Microsoft Research. All rights reserved. 
+ *
+ * The MIT License (MIT)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software. 
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool.liveness;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+
+public class LivenessConstraintWarning extends ModelCheckerTestCase {
+
+	public LivenessConstraintWarning() {
+		super("LivenessConstraintWarning");
+	}
+	
+	@Test
+	public void testSpec() {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+		assertTrue(recorder.recorded(EC.TLC_FEATURE_LIVENESS_CONSTRAINTS));
+		assertFalse(recorder.recorded(EC.GENERAL));
+	}
+}


### PR DESCRIPTION
Declaring action constraints during liveness checking is dangerous:
All behaviors might end in infinite stuttering and thus do not satisfy
the spec's fairness constraints. Be sure to check a liveness property
such as '<>FALSE' to verify that TLC reports liveness errors. Please
read section 14.3.5  on page 247 of Specifying Systems for more details
(https://lamport.azurewebsites.net/tla/book.html)

See discussion in http://discuss.tlapl.us/msg00994.html

[Feature][TLC][Toolbox][Changelog]